### PR TITLE
Use functional updater for save

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,9 @@ export default function App() {
   const totalEarned = useMemo(() => state.actions.reduce((s,a)=>s+a.stars,0), [state.actions])
   const totalSpent = useMemo(() => state.redemptions.reduce((s,r)=>s+r.cost,0), [state.redemptions])
 
-  function save(patch: Partial<State>) { setState({ ...state, ...patch }) }
+  function save(patch: Partial<State>) {
+    setState(prev => ({ ...prev, ...patch }))
+  }
   function addStars(n: number){
     save({ child: { ...state.child, stars: Math.max(0, state.child.stars + n) } })
   }


### PR DESCRIPTION
## Summary
- replace `save` with functional state updater to merge concurrent patches
- ensure `addStars` and `pushAction` continue to call `save` individually so star increments persist

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- simulated sequential `addStars` + `pushAction` calls verifying star count increments


------
https://chatgpt.com/codex/tasks/task_e_6896b2c162e88329a4847ca576bd70e6